### PR TITLE
Fix: Max Loadcell limit validation

### DIFF
--- a/PedalBox/Pedal.h
+++ b/PedalBox/Pedal.h
@@ -65,7 +65,7 @@ class Pedal
       if (_signal == 1) {
         rawValue = _loadCell.get_value(1);
         if (rawValue > _loadcell_max_val) {
-          rawValue = 0;
+          rawValue = _loadcell_max_val;
         }
         if (rawValue < 0) rawValue = 0;
         rawValue /= _loadcell_scaling;


### PR DESCRIPTION
Pushing over the defined loadcell limit the value was resetting the value to 0 instead of just set to _loadcell_max_val
This can be very dangerous for example if you press over 100% on brakes and the it just goes to zero :D